### PR TITLE
Changed Müsli contact information

### DIFF
--- a/muesli/web/templates/contact.pt
+++ b/muesli/web/templates/contact.pt
@@ -14,7 +14,7 @@ Bei Problemen mit MÜSLI selbst <a tal:attributes="href 'mailto:'+request.config
 </p>
 
 <p>
-Es gibt auch eine <a href="http://www.mathi.uni-heidelberg.de/~ansgar/muesli">Webseite zu MÜSLI</a> selbst.
+Der Quelltext von Müsli kann auf <a href="https://github.com/muesli-hd/muesli">Github</a> eingesehen werden. Auch Verbesserungsvorschläge können dort abgegeben werden.
 </p>
 
 


### PR DESCRIPTION
There is an old website with an outdated git-repository linked from within müsli. I stumbled upon this when I tried to contribute a patch. The Mailinglist mentioned there does not seem to be in use anymore.

I changed the link provided there to this github repository, but an other option would be to create a new website for müsli. Personally I think updating the README file in the root of this project would be a good alternative to a new website, since all Information we would be able to provide over a website could be put in a equally good formated Markdown file.