### PR TITLE
Changed shebang of muesli-test, muesli-serve to use python3

### DIFF
--- a/muesli-serve
+++ b/muesli-serve
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # muesli-serve
 #

--- a/muesli-test
+++ b/muesli-test
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # muesli-test
 #


### PR DESCRIPTION
Changed the shebang to explicitly use python3, so muesli-test/muesli-serve can function when only python3 modules are installed on systems with python=python2 (for example Ubuntu 16.04/18.04).