### PR TITLE
Extend the docker-serve-script to display IP of container, fix Bug regarding js-lib load order

### DIFF
--- a/muesli/web/__init__.py
+++ b/muesli/web/__init__.py
@@ -85,7 +85,7 @@ def add_session_to_request(event):
     #event.request.gc = gc
 @subscriber(NewRequest)
 def add_javascript_to_request(event):
-    event.request.javascript = set()
+    event.request.javascript = list()
 
 @subscriber(NewRequest)
 def add_config_to_request(event):

--- a/muesli/web/viewsExam.py
+++ b/muesli/web/viewsExam.py
@@ -197,7 +197,7 @@ class EnterPointsBasic(object):
         else:
             statistics = exam.getStatistics(students=students)
         if not self.raw:
-            self.request.javascript.add('prototype.js')
+            self.request.javascript.append('prototype.js')
         return {'exam': exam,
                 'tutorial_ids': self.request.matchdict['tutorial_ids'],
                 'students': students,
@@ -363,7 +363,7 @@ def statistics(request):
         for i,q in enumerate(exam.getQuantils(students=tutorialstudents)):
             quantils[i]['tutorial'] = q
         #quantils['tutorials'] = exam.getQuantils(students=tutorialstudents)
-    request.javascript.add('prototype.js')
+    request.javascript.append('prototype.js')
     #pointsQuery = exam.exercise_points.filter(ExerciseStudent.student_id.in_([s.student.id for s  in students])).options(sqlalchemy.orm.joinedload(ExerciseStudent.student, ExerciseStudent.exercise))
     #points = DictOfObjects(lambda: {})
     #for point in pointsQuery:
@@ -553,8 +553,8 @@ class Correlation(MatplotlibView):
 def enterPointsSingle(request):
     exam = request.context.exam
     exercises = exam.exercises
-    request.javascript.add('prototype.js')
-    request.javascript.add('scriptaculous/scriptaculous.js')
+    request.javascript.append('prototype.js')
+    request.javascript.append('scriptaculous/scriptaculous.js')
     show_tutor = not request.context.tutorials
     show_time = (not request.context.tutorials) or len(request.context.tutorials) > 1
     code = """

--- a/muesli/web/viewsGrading.py
+++ b/muesli/web/viewsGrading.py
@@ -196,9 +196,9 @@ class EnterGradesBasic(object):
                 error_msgs.append(str(err))
         if 'fill' in self.request.GET:
             self.request.session.flash('Achtung, die Noten sind noch nicht abgespeichert!', queue='errors')
-        #self.request.javascript.add('prototype.js')
-        self.request.javascript.add('jquery/jquery.min.js')
-        self.request.javascript.add('jquery/jquery.fancybox.min.js')
+        #self.request.javascript.append('prototype.js')
+        self.request.javascript.append('jquery/jquery.min.js')
+        self.request.javascript.append('jquery/jquery.fancybox.min.js')
         #grades = {key: value for key,value in grades.items()}
 
         return {'grading': grading,

--- a/muesli/web/viewsTutorial.py
+++ b/muesli/web/viewsTutorial.py
@@ -156,8 +156,8 @@ def results(request):
     cat_maxpoints = dict([cat['id'], 0] for cat in utils.categories)
     for exam in lecture.exams:
         cat_maxpoints[exam.category] += exam.getMaxpoints()
-    request.javascript.add('jquery/jquery.min.js')
-    request.javascript.add('jquery/jquery.tablesorter.min.js')
+    request.javascript.append('jquery/jquery.min.js')
+    request.javascript.append('jquery/jquery.tablesorter.min.js')
     return {'tutorials': tutorials,
             'tutorial_ids': request.context.tutorial_ids,
             'lecture_students': lecture_students,


### PR DESCRIPTION
This is usefull, if the port is blocked/in use, since one can use the IP-Address directly (at least on linux-systems).