### PR TITLE
Fix für fehlerhaften Link in Punkteübersicht 

### DIFF
--- a/muesli/web/viewsTutorial.py
+++ b/muesli/web/viewsTutorial.py
@@ -159,7 +159,7 @@ def results(request):
     request.javascript.add('jquery/jquery.min.js')
     request.javascript.add('jquery/jquery.tablesorter.min.js')
     return {'tutorials': tutorials,
-            'tutorial_ids': request.context.tutorial_ids,
+            'tutorial_ids': request.context.tutorial_ids_str,
             'lecture_students': lecture_students,
             'results': results,
             'names': request.config['lecture_types'][lecture.type],


### PR DESCRIPTION
Wenn man in der Punkteübersicht ist und über ein Übungszettel bei einem Studenten hovered und dann auf einen der Zettel klickt ist der Link kaputt. Was daran liegt das hier `tutorial_ids` eine Liste ist anstelle von einem int.
![muesli](https://user-images.githubusercontent.com/16564897/51076006-5430d200-1693-11e9-8dcf-39c5b5a106a1.png)
![selection_134](https://user-images.githubusercontent.com/16564897/51076019-7fb3bc80-1693-11e9-80b7-51c0cc0fc489.png)

