### PR TITLE
Längen-lexikografische Sortierung

### DIFF
--- a/muesli/web/templates/lecture/edit.pt
+++ b/muesli/web/templates/lecture/edit.pt
@@ -103,7 +103,7 @@ Zu dieser ${names['name']} werden die folgenden ${names['tutorials']} angeboten:
 <p><a tal:attributes="href request.route_path('lecture_add_exam', lecture_id=lecture.id)">Testat hinzufügen</a></p>
 
 <div tal:repeat="category categories" tal:omit-tag="">
-  <h4 tal:condition="len(exams[category['id']])!=0">${category['name']}</h4>
+  <h4 tal:condition="exams[category['id']]">${category['name']}</h4>
   <ul>
     <li tal:repeat="exam exams[category['id']]">
         <a tal:attributes="href request.route_path('exam_edit', exam_id=exam.id)">${exam.name}</a> (<a tal:attributes="href request.route_path('exam_statistics', exam_id=exam.id, tutorial_ids='')">Statistiken</a>,

--- a/muesli/web/templates/lecture/edit.pt
+++ b/muesli/web/templates/lecture/edit.pt
@@ -103,7 +103,7 @@ Zu dieser ${names['name']} werden die folgenden ${names['tutorials']} angeboten:
 <p><a tal:attributes="href request.route_path('lecture_add_exam', lecture_id=lecture.id)">Testat hinzufügen</a></p>
 
 <div tal:repeat="category categories" tal:omit-tag="">
-  <h4 tal:condition="exams[category['id']].count()!=0">${category['name']}</h4>
+  <h4 tal:condition="len(exams[category['id']])!=0">${category['name']}</h4>
   <ul>
     <li tal:repeat="exam exams[category['id']]">
         <a tal:attributes="href request.route_path('exam_edit', exam_id=exam.id)">${exam.name}</a> (<a tal:attributes="href request.route_path('exam_statistics', exam_id=exam.id, tutorial_ids='')">Statistiken</a>,

--- a/muesli/web/templates/tutorial/view.pt
+++ b/muesli/web/templates/tutorial/view.pt
@@ -33,7 +33,7 @@ set_navigation([['Vorlesung ${tutorial.lecture.name}','${request.route_path("lec
 <h3>Testate</h3>
 
 <div tal:repeat="category categories" tal:omit-tag="">
-  <h4 tal:condition="len(exams[category['id']])!=0">${category['name']}</h4>
+  <h4 tal:condition="exams[category['id']]">${category['name']}</h4>
 
   <ul>
     <li tal:repeat="exam exams[category['id']]">

--- a/muesli/web/templates/tutorial/view.pt
+++ b/muesli/web/templates/tutorial/view.pt
@@ -33,7 +33,7 @@ set_navigation([['Vorlesung ${tutorial.lecture.name}','${request.route_path("lec
 <h3>Testate</h3>
 
 <div tal:repeat="category categories" tal:omit-tag="">
-  <h4 tal:condition="exams[category['id']].count()!=0">${category['name']}</h4>
+  <h4 tal:condition="len(exams[category['id']])!=0">${category['name']}</h4>
 
   <ul>
     <li tal:repeat="exam exams[category['id']]">

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -605,8 +605,12 @@ def viewPoints(request):
         return HTTPForbidden()
     visible_exams = lecture.exams.filter((models.Exam.results_hidden==False)|(models.Exam.results_hidden==None))
     exams = visible_exams.all()
+    # Query results are already lexicographically sorted.
+    # Sort again using length as key so we get length lexicographical sorting
+    # https://github.com/muesli-hd/muesli/issues/28
     exams_by_category = [
-            {'id':cat['id'], 'name': cat['name'], 'exams': visible_exams.filter(models.Exam.category==cat['id']).all()} for cat in utils.categories]
+            {'id':cat['id'], 'name': cat['name'], 'exams': sorted(list(visible_exams.filter(models.Exam.category==cat['id']).all()),
+             key=lambda x:len(x.name))} for cat in utils.categories]
     exams_by_category = [cat for cat in exams_by_category if cat['exams']]
     results = {}
     for exam in exams:

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -265,13 +265,19 @@ class Edit:
         pref_count = sum([pref[0] for pref in pref_subjects])
         subjects = lecture.subjects()
         student_count = sum([subj[0] for subj in subjects])
+        # Query results are already lexicographically sorted.
+        # Sort again using length as key so we get length lexicographical sorting
+        # https://github.com/muesli-hd/muesli/issues/28
+        exams = dict([[cat['id'], sorted(list(lecture.exams.filter(models.Exam.category==cat['id'])),
+                              key=lambda x:len(x.name))]
+                      for cat in utils.categories])
         return {'lecture': lecture,
                 'names': names,
                 'pref_count': pref_count,
                 'subjects': subjects,
                 'student_count': student_count,
                 'categories': utils.categories,
-                'exams': dict([[cat['id'], lecture.exams.filter(models.Exam.category==cat['id'])] for cat in utils.categories]),
+                'exams': exams,
                 'assistants': assistants,
                 'form': form}
 

--- a/muesli/web/viewsTutorial.py
+++ b/muesli/web/viewsTutorial.py
@@ -52,13 +52,19 @@ class View:
         students = [ls.student for ls in lecture_students] #self.db.query(models.User).filter(filterClause)
         tutorial = tutorials[0]
         other_tutorials = tutorial.lecture.tutorials
+        # Query results are already lexicographically sorted.
+        # Sort again using length as key so we get length lexicographical sorting
+        # https://github.com/muesli-hd/muesli/issues/28
+        exams = dict([[cat['id'], sorted(list(tutorial.lecture.exams.filter(models.Exam.category==cat['id'])),
+                                         key=lambda x: len(x.name))]
+                      for cat in utils.categories])
         return {'tutorial': tutorial,
                 'tutorials': tutorials,
                 'tutorial_ids': self.tutorial_ids,
                 'other_tutorials': other_tutorials,
                 'students': students,
                 'categories': utils.categories,
-                'exams': dict([[cat['id'], tutorial.lecture.exams.filter(models.Exam.category==cat['id'])] for cat in utils.categories]),
+                'exams': exams,
                 'names': self.request.config['lecture_types'][tutorial.lecture.type],
                 'old_tutorial_id': None  #see move_student
                 }


### PR DESCRIPTION
Hallo!

Ich habe eine längen-lexikographische Sortierung für die Routen "lecture_view", "tutorial_view" und "lecture_view_points" implementiert.

Da die Resultate aus der Datenbank bereits lexikografisch sortiert sind, musste ich nur mit der Länge als key sortieren.

Im Frontend musste ich jedoch dann von der `count` Funktion  umsteigen auf `len`, da das, was beim Frontend ankommt, eine normale python Liste ist, und keine Query mehr:

```diff
- <h4 tal:condition="exams[category['id']].count()!=0">${category['name']}</h4>
+ <h4 tal:condition="len(exams[category['id']])!=0">${category['name']}</h4>
```

Mir ist aber aufgefallen, als ich nach dem Ausdruck "lecture.exams.filter" gesucht habe, dass dieser sehr oft vorkommt und um einheitlich zu bleiben bei der Sortierung müsste man diesen Code dort überall einfügen und ggf. eben das Frontend passen, wenn es `count` benutzt. Ist nämlich vielleicht etwas komisch, zwei Sortierungen nun anzutreffen?

Da mir das aber etwas zu voreilig vorkam, wollte ich erstmal hier meine Änderung präsentieren.

closes https://github.com/muesli-hd/muesli/issues/28