### PR TITLE
Show more informative error message on failed login

### DIFF
--- a/muesli/web/viewsUser.py
+++ b/muesli/web/viewsUser.py
@@ -53,7 +53,7 @@ def login(request):
             request.user = user
             url = request.route_url('start')
             return HTTPFound(location=url)
-        request.session.flash('Nicht gefunden', queue='errors')
+        request.session.flash('Benutzername oder Passwort sind falsch.', queue='errors')
     return {'form': form, 'user': security.authenticated_userid(request)}
 
 


### PR DESCRIPTION
Previously, the error message on a failed login just read "Nicht gefunden" (i.e. "Not found").
This pull request changes the error message to "Benutzername oder Passwort sind falsch." (i.e. "User name or password are wrong").