### PR TITLE
Show "austreten" instead of "wechseln" link when already subscribed to a tutorial

### DIFF
--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -48,9 +48,12 @@
           <a tal:attributes="href request.route_path('tutorial_view', tutorial_ids=tutorial.id)">Details</a>
         </td>
         <td>
-          <a tal:condition='tutorial.student_count &lt; tutorial.max_students '
+          <a tal:condition='(tutorial.student_count &lt; tutorial.max_students) and tutorial.id != subscribed_tutorial_id'
              tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
-             ${'Wechseln' if subscribed else 'Beitreten'}
+             ${'Wechseln' if subscribed_to_any_tutorial else 'Beitreten'}
+          </a>
+          <a tal:condition='tutorial.id == subscribed_tutorial_id' tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
+            Austreten
           </a>
         </td>
       </tr>

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -48,11 +48,12 @@
           <a tal:attributes="href request.route_path('tutorial_view', tutorial_ids=tutorial.id)">Details</a>
         </td>
         <td>
-          <a tal:condition='(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial'
+          <a tal:condition="(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial"
              tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
-             ${'Wechseln' if not subscribed_tutorial else 'Beitreten'} <!-- TODO: Die Logik hier stimmt noch nicht, fixen -->
+            ${'Beitreten' if not subscribed_tutorial else 'Wechseln'}
           </a>
-          <a tal:condition='tutorial == subscribed_tutorial' tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
+          <a tal:condition="tutorial == subscribed_tutorial"
+             tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
             Austreten
           </a>
         </td>

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -50,7 +50,7 @@
         <td>
           <a tal:condition='(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial'
              tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
-             ${'Wechseln' if not subscribed_tutorial else 'Beitreten'}
+             ${'Wechseln' if not subscribed_tutorial else 'Beitreten'} <!-- TODO: Die Logik hier stimmt noch nicht, fixen -->
           </a>
           <a tal:condition='tutorial == subscribed_tutorial' tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
             Austreten

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -48,11 +48,11 @@
           <a tal:attributes="href request.route_path('tutorial_view', tutorial_ids=tutorial.id)">Details</a>
         </td>
         <td>
-          <a tal:condition='(tutorial.student_count &lt; tutorial.max_students) and tutorial.id != subscribed_tutorial_id'
+          <a tal:condition='(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial'
              tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
-             ${'Wechseln' if subscribed_to_any_tutorial else 'Beitreten'}
+             ${'Wechseln' if not subscribed_tutorial else 'Beitreten'}
           </a>
-          <a tal:condition='tutorial.id == subscribed_tutorial_id' tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
+          <a tal:condition='tutorial == subscribed_tutorial' tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
             Austreten
           </a>
         </td>

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -84,11 +84,9 @@ class View:
     def __call__(self):
         lecture = self.db.query(models.Lecture).options(undefer('tutorials.student_count')).get(self.lecture_id)
         times = lecture.prepareTimePreferences(user=self.request.user)
-        subscribed_to_any_tutorial = self.request.user.id in [s.id for s in lecture.students]
-        subscribed_tutorial_id = None  # TODO Determine the ID of the tutorial to which the student is subscribed
+        subscribed_tutorial = None  # TODO Determine the tutorial the student is subscribed to, if any
         return {'lecture': lecture,
-                'subscribed_to_any_tutorial': subscribed_to_any_tutorial,
-                'subscribed_tutorial_id': subscribed_tutorial_id,
+                'subscribed_tutorial': subscribed_tutorial,
                 'times': times,
                 'prefs': utils.preferences}
 

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -83,14 +83,12 @@ class View:
         self.lecture_id = request.matchdict['lecture_id']
     def __call__(self):
         lecture = self.db.query(models.Lecture).options(undefer('tutorials.student_count')).get(self.lecture_id)
-        print(lecture)
         times = lecture.prepareTimePreferences(user=self.request.user)
         subscribed_tutorial = self.db.query(models.Tutorial).filter(
             Tutorial.lecture_students.any(
                 LectureStudent.student_id == self.request.user.id and LectureStudent.lecture_id == self.lecture_id
             )
         ).first()
-        print(subscribed_tutorial)
         return {'lecture': lecture,
                 'subscribed_tutorial': subscribed_tutorial,
                 'times': times,

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -84,9 +84,11 @@ class View:
     def __call__(self):
         lecture = self.db.query(models.Lecture).options(undefer('tutorials.student_count')).get(self.lecture_id)
         times = lecture.prepareTimePreferences(user=self.request.user)
-        subscribed = self.request.user.id in [s.id for s in lecture.students]
+        subscribed_to_any_tutorial = self.request.user.id in [s.id for s in lecture.students]
+        subscribed_tutorial_id = None  # TODO Determine the ID of the tutorial to which the student is subscribed
         return {'lecture': lecture,
-                'subscribed': subscribed,
+                'subscribed_to_any_tutorial': subscribed_to_any_tutorial,
+                'subscribed_tutorial_id': subscribed_tutorial_id,
                 'times': times,
                 'prefs': utils.preferences}
 

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -83,8 +83,14 @@ class View:
         self.lecture_id = request.matchdict['lecture_id']
     def __call__(self):
         lecture = self.db.query(models.Lecture).options(undefer('tutorials.student_count')).get(self.lecture_id)
+        print(lecture)
         times = lecture.prepareTimePreferences(user=self.request.user)
-        subscribed_tutorial = None  # TODO Determine the tutorial the student is subscribed to, if any
+        subscribed_tutorial = self.db.query(models.Tutorial).filter(
+            Tutorial.lecture_students.any(
+                LectureStudent.student_id == self.request.user.id and LectureStudent.lecture_id == self.lecture_id
+            )
+        ).first()
+        print(subscribed_tutorial)
         return {'lecture': lecture,
                 'subscribed_tutorial': subscribed_tutorial,
                 'times': times,

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -84,11 +84,7 @@ class View:
     def __call__(self):
         lecture = self.db.query(models.Lecture).options(undefer('tutorials.student_count')).get(self.lecture_id)
         times = lecture.prepareTimePreferences(user=self.request.user)
-        subscribed_tutorial = self.db.query(models.Tutorial).filter(
-            Tutorial.lecture_students.any(
-                LectureStudent.student_id == self.request.user.id and LectureStudent.lecture_id == self.lecture_id
-            )
-        ).first()
+        subscribed_tutorial = self.request.user.tutorials.filter(LectureStudent.lecture_id == self.lecture_id).first()
         return {'lecture': lecture,
                 'subscribed_tutorial': subscribed_tutorial,
                 'times': times,


### PR DESCRIPTION
Closes #15.

This pull request introduces the following changes:

1. The lecture view will show an "Austreten" link instead of a "Wechseln" link for the tutorial the user has joined (if any)
2. Backend will send a full `subscribed_tutorial` tutorial object instead of just a `subscribed` boolean that indicates whether the user is subscribed to any tutorial