### PR TITLE
Better distinction between UI elements for navigation and UI elements for performing actions

### DIFF
--- a/muesli/web/static/css/muesli.css
+++ b/muesli/web/static/css/muesli.css
@@ -291,3 +291,25 @@ table.colored tr:nth-child(odd) {
     padding-top: 0;
     padding-bottom: 0;
 }
+
+/* Button-like <a> elements for any <a> that actually triggers an action */
+a.action {
+    background-color: lightgray;
+    padding: 3px 8px;
+    text-decoration: none;
+    border-radius: 4px;
+    color:black;
+    box-shadow: 1px 1px 2px black;
+    line-height: 21px;
+    cursor: default;
+    margin: 0 2px 2px 0;
+}
+
+a.action:hover {
+    background-color: #eee;
+}
+
+a.action:active {
+    box-shadow: none;
+    margin: 2px 0 0 2px;
+}

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -48,7 +48,7 @@
             ${tutorial.tutor.first_name} ${tutorial.tutor.last_name}
           </span>
           <span tal:omit-tag='' tal:condition="not tutorial.tutor and request.permissionInfo.has_permission('take_tutorial')"> <!-- TODO: and (is assistant or is_tutor) -->
-            <a tal:attributes="href request.route_path('tutorial_take', tutorial_id=tutorial.id)">Übernehmen</a>
+            <a class="action" tal:attributes="href request.route_path('tutorial_take', tutorial_id=tutorial.id)">Übernehmen</a>
           </span>
         </td>
         <td>${tutorial.comment}</td>

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -56,11 +56,11 @@
           <a tal:attributes="href request.route_path('tutorial_view', tutorial_ids=tutorial.id)">Details</a>
         </td>
         <td>
-          <a tal:condition="(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial"
-              tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
+          <a class="action" tal:condition="(tutorial.student_count &lt; tutorial.max_students) and tutorial != subscribed_tutorial"
+             tal:attributes="href request.route_path('tutorial_subscribe', tutorial_id=tutorial.id)">
             ${'Beitreten' if not subscribed_tutorial else 'Wechseln'}
           </a>
-          <a tal:condition="tutorial == subscribed_tutorial" onclick="return confirm_unsubscribe()"
+          <a class="action" tal:condition="tutorial == subscribed_tutorial"
              tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">
             Austreten
           </a>

--- a/muesli/web/templates/lecture/view.pt
+++ b/muesli/web/templates/lecture/view.pt
@@ -2,13 +2,6 @@
 <metal:main metal:use-macro="templates('Fragments/main.pt').macros['main']">
   <metal:main metal:fill-slot="content">
 
-<script>
-  function confirm_unsubscribe() {
-    return confirm("Wollen Sie wirklich diese Übungsgruppe verlassen?");
-  }
-</script>
-
-
   <h2>${lecture.name}</h2>
 
   <p tal:condition="lecture.url">

--- a/muesli/web/templates/start.pt
+++ b/muesli/web/templates/start.pt
@@ -56,7 +56,7 @@
       <td>${tutorial.place}</td>
       <td>
         <a tal:condition="tutorial.tutor" tal:attributes="href 'mailto:'+tutorial.tutor.email">${tutorial.tutor.name()}</a></td>
-      <td><a tal:attributes="href request.route_path('lecture_view_points', lecture_id=tutorial.lecture.id)">[&nbsp;Details&nbsp;]</a></td>
+      <td><a tal:attributes="href request.route_path('lecture_view_points', lecture_id=tutorial.lecture.id)">Punkte und Klausuren</a></td>
       <td>
         <a tal:condition="tutorial.lecture.mode != 'static'" onclick="return confirm_unsubscribe()"
            tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">[&nbsp;Austreten&nbsp;]</a>

--- a/muesli/web/templates/start.pt
+++ b/muesli/web/templates/start.pt
@@ -2,15 +2,6 @@
 <metal:main metal:use-macro="templates('Fragments/main.pt').macros['main']">
   <metal:main metal:fill-slot="content">
 
-<script>
-/*<![CDATA[*/
-  function confirm_unsubscribe() {
-    return confirm("Wollen Sie wirklich diese Übungsgruppe verlassen?");
-  }
-/*]]>*/
-</script>
-
-
 <div tal:condition="uboo">
     Bitte nehmen Sie sich die Zeit zu überprüfen, ob noch alle Ihre Angaben korrekt sind. Dies ist insbesondere wichtig,
     wenn Sie den Studiengang gewechselt haben.<br>

--- a/muesli/web/templates/start.pt
+++ b/muesli/web/templates/start.pt
@@ -47,7 +47,7 @@
 <div tal:condition="tutorials">
   <h3>Feste Eintragungen in Übungsgruppen</h3>
   <table>
-    <tr><th></th><th>Vorlesung</th><th>Zeit</th><th>Raum</th><th>Übungsleiter</th><th></th><th></th></tr>
+    <tr><th></th><th>Vorlesung</th><th>Zeit</th><th>Raum</th><th>Übungsleiter</th><th></th></tr>
 
     <tr tal:repeat="tutorial tutorials">
       <td>${tutorial.lecture.term}</td>
@@ -57,10 +57,6 @@
       <td>
         <a tal:condition="tutorial.tutor" tal:attributes="href 'mailto:'+tutorial.tutor.email">${tutorial.tutor.name()}</a></td>
       <td><a tal:attributes="href request.route_path('lecture_view_points', lecture_id=tutorial.lecture.id)">Punkte und Klausuren</a></td>
-      <td>
-        <a tal:condition="tutorial.lecture.mode != 'static'" onclick="return confirm_unsubscribe()"
-           tal:attributes="href request.route_path('tutorial_unsubscribe', tutorial_id=tutorial.id)">[&nbsp;Austreten&nbsp;]</a>
-      </td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
Closes #88.

This pull request will introduce the following changes:

1. Create a style for `a.action` that makes them appear like buttons
1. Add the action attribute to some `<a>` that actually perform actions
1. Remove the unsubscribe link for tutorials from the overview page (with #92, the unsubscribe feature is implemented on the lecture page, so I think we don't need it twice - furthermore, this hopefully helps to prevent accidental unsubscribing from the overview page)
1. Rename the "Details" link for a tutorial to "Punkte und Klausuren" to provide more details on where clicking this link will take you.

With this PR, I want to introduce the general idea of having button-like `<a>` tags to MÜSLI. When this is merged, I'll probably suggest a bigger bunch of action `<a>` tags that should actually be buttons.

For now, I'm ready to merge this.