### PR TITLE
Swap tutors and assistants as mail recipients

### DIFF
--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -449,8 +449,8 @@ def emailTutors(request):
         tutors = lecture.tutors
         message = Message(subject=form['subject'],
                 sender=request.user.email,
-                to= [assistant.email for assistant in lecture.assistants],
-                cc=[t.email for t in tutors],
+                to=[t.email for t in tutors],
+                cc=[assistant.email for assistant in lecture.assistants],
                 body=form['body'])
         if request.POST['attachments'] not in ['', None]:
             message.attach(request.POST['attachments'].filename, data=request.POST['attachments'].file)


### PR DESCRIPTION
The tutors should be the main recipients, the assistants only the ones that get a copy (as the feature is named `emailTutors` and not `emailAssistants`.

This is arguably a pretty minor change, but it will help me when implementing a solution for #91.

Closes #96.