### PR TITLE
Forbid letters in matrikel (client-side)

### DIFF
--- a/muesli/web/forms.py
+++ b/muesli/web/forms.py
@@ -481,7 +481,8 @@ class UserRegister(ObjectForm):
                    label='Matrikelnummer', size=10, comment='Falls noch keine Matrikelnummer bekannt ist bitte 00000 eintragen. Die Matrikelnummer muss dann baldmöglichst unter „Angaben ergänzen“ richtig gestellt werden!',
                    validator=validators.Number,
                    #value=user.matrikel,
-                   required=True
+                   required=True,
+                   type="number"
                    ),
                 FormField('subject',
                    label='Studiengang',

--- a/muesli/web/templates/Fragments/HTML/form.pt
+++ b/muesli/web/templates/Fragments/HTML/form.pt
@@ -26,6 +26,9 @@
           <div tal:condition="field.type=='text'" tal:omit-tag="">
             <input tal:attributes="name field.name; size str(field.size); value field.value; readonly 'readonly' if field.readonly else None"/>
           </div>
+          <div tal:condition="field.type=='number'" tal:omit-tag="">
+            <input type="number" tal:attributes="name field.name; size str(field.size); value field.value; readonly 'readonly' if field.readonly else None"/>
+          </div>
           <div tal:condition="field.type=='password'" tal:omit-tag="">
             <input type="password" tal:attributes="name field.name; size str(field.size); value field.value; readonly 'readonly' if field.readonly else None"/>
           </div>


### PR DESCRIPTION
This will change the matriculation number input field to a `type=number` input field, meaning that clients will prevent users from entering anything that is not a number (for example, their Uni-ID).

Closes #19.