### PR TITLE
verify old_password when user changes password

### DIFF
--- a/muesli/web/viewsUser.py
+++ b/muesli/web/viewsUser.py
@@ -464,9 +464,13 @@ def confirmEmail(request):
 def changePassword(request):
     form = forms.UserChangePassword(request)
     if request.method == 'POST' and form.processPostData(request.POST):
-        request.user.password = sha1(form['new_password'].encode('utf-8')).hexdigest()
-        request.session.flash('Neues Passwort gesetzt', queue='messages')
-        request.db.commit()
+        # check if old_password is correct
+        if request.user.password == sha1(form['old_password'].encode('utf-8')).hexdigest():
+            request.user.password = sha1(form['new_password'].encode('utf-8')).hexdigest()
+            request.session.flash('Neues Passwort gesetzt', queue='messages')
+            request.db.commit()
+        else:
+            request.session.flash('Altes Passwort ist falsch!', queue='errors')
     return {'form': form}
 
 


### PR DESCRIPTION
Currently you can type in whatever `old_password` you want, your password will always be changed, as long as the `new_password` and `new_password_repeat` match. This is a potential security risk.