### PR TITLE
Add note about required data for registration

### DIFF
--- a/muesli/web/templates/user/register.pt
+++ b/muesli/web/templates/user/register.pt
@@ -19,7 +19,7 @@ Verwenden Sie eine Mailadresse unter <strong>uni-heidelberg.de</strong>, beispie
     <h2 style="color: red">Mailversand wegen Spamaktivität deaktiviert.</h2>
     <p>Wegen akuter Spamaktivität ist die Registrierung neuer Accounts im MÜSLI System aktuell deaktiviert. Falls Sie
       einen Account benötigen, <a tal:attributes="href 'mailto:'+request.config['contact']['email']">schreiben Sie uns bitte
-        eine Email</a>.</p>
+        eine Email</a> mit Ihrem Vor- und Nachnamen, Ihrer Matrikelnummer und Ihrem Studiengang (z.B. "Mathematik BSc 100%").</p>
 
     <!--
 <form action="/user/register" tal:attributes="action request.route_path('user_register')" method="POST">


### PR DESCRIPTION
To avoid unnecessary back and forth when users want to create a new MÜSLI account, I'd propose to add the required data directly in the sign up message.

Looking forward to the probable influx of students that want to register a new account in the next month (beginning of the next semester), I assume this might reduce the admin's workload.