### PR TITLE
Display relative percentage of achieved points on view_points

### DIFF
--- a/muesli/models.py
+++ b/muesli/models.py
@@ -371,7 +371,11 @@ class Exam(Base):
         for points in pointsQuery.all():
             results[points.exercise_id] = {'points': points.points,
                                            'exercise': points.exercise}
-        results['sum'] = sum([x for x in [r['points'] for r in list(results.values())] if x])
+        nonNullPoints = [x for x in [r['points'] for r in list(results.values())] if x]
+        if len(nonNullPoints) > 0:
+            results['sum'] = sum(nonNullPoints)
+        else:
+            results['sum'] = None
         for e in self.exercises:
             if e.id not in results:
                 results[e.id] = {'points': None, 'exercise': e}

--- a/muesli/models.py
+++ b/muesli/models.py
@@ -371,8 +371,8 @@ class Exam(Base):
         for points in pointsQuery.all():
             results[points.exercise_id] = {'points': points.points,
                                            'exercise': points.exercise}
-        nonNullPoints = [x for x in [r['points'] for r in list(results.values())] if x]
-        if len(nonNullPoints) > 0:
+        nonNullPoints = [x for x in [r['points'] for r in results.values()] if x]
+        if nonNullPoints:
             results['sum'] = sum(nonNullPoints)
         else:
             results['sum'] = None

--- a/muesli/web/templates/lecture/view_points.pt
+++ b/muesli/web/templates/lecture/view_points.pt
@@ -24,7 +24,7 @@
       </tr>
     <tr>
       <th>Insgesamt</th>
-      <td colspan="2"><strong>${fF(catexams['sum'])}/${fF(catexams['max'])}</strong>
+      <td colspan="3"><strong>${fF(catexams['sum'])}/${fF(catexams['max'])}</strong>
         <span tal:condition="catexams['max']>0">
          (${'%2.f' % (catexams['sum']/catexams['max']*100)}%, ${'%2.f' % (catexams['sum']/catexams['max_rel']*100)}% rel.)
         </span>

--- a/muesli/web/templates/lecture/view_points.pt
+++ b/muesli/web/templates/lecture/view_points.pt
@@ -25,8 +25,11 @@
     <tr>
       <th>Insgesamt</th>
       <td colspan="3"><strong>${fF(catexams['sum'])}/${fF(catexams['max'])}</strong>
-        <span tal:condition="catexams['max']>0">
+        <span tal:condition="catexams['max']>0 and catexams['max']!=catexams['max_rel']">
          (${'%2.f' % (catexams['sum']/catexams['max']*100)}%, ${'%2.f' % (catexams['sum']/catexams['max_rel']*100)}% rel.)
+        </span>
+        <span tal:condition="catexams['max']>0 and catexams['max']==catexams['max_rel']">
+         (${'%2.f' % (catexams['sum']/catexams['max']*100)}%)
         </span>
      </td>
     </tr>

--- a/muesli/web/templates/lecture/view_points.pt
+++ b/muesli/web/templates/lecture/view_points.pt
@@ -25,7 +25,7 @@
     <tr>
       <th>Insgesamt</th>
       <td colspan="3"><strong>${fF(catexams['sum'])}/${fF(catexams['max'])}</strong>
-        <span tal:condition="catexams['max']>0 and catexams['max']!=catexams['max_rel']">
+        <span tal:condition="catexams['max']>0 and catexams['max_rel']>0 and catexams['max']!=catexams['max_rel']">
          (${'%2.f' % (catexams['sum']/catexams['max']*100)}%, ${'%2.f' % (catexams['sum']/catexams['max_rel']*100)}% rel.)
         </span>
         <span tal:condition="catexams['max']>0 and catexams['max']==catexams['max_rel']">

--- a/muesli/web/templates/lecture/view_points.pt
+++ b/muesli/web/templates/lecture/view_points.pt
@@ -26,7 +26,7 @@
       <th>Insgesamt</th>
       <td colspan="2"><strong>${fF(catexams['sum'])}/${fF(catexams['max'])}</strong>
         <span tal:condition="catexams['max']>0">
-         (${'%2.f' % (catexams['sum']/catexams['max']*100)}%)
+         (${'%2.f' % (catexams['sum']/catexams['max']*100)}%, ${'%2.f' % (catexams['sum']/catexams['max_rel']*100)}% rel.)
         </span>
      </td>
     </tr>

--- a/muesli/web/viewsLecture.py
+++ b/muesli/web/viewsLecture.py
@@ -621,8 +621,10 @@ def viewPoints(request):
     for exams in exams_by_category:
         sum_all = sum([x for x in [results[e.id]['sum'] for e in exams['exams']] if x])
         max_all = sum([x for x in [e.getMaxpoints() for e in exams['exams']] if x])
+        max_rel = sum([x for x in [e.getMaxpoints() for e in exams['exams'] if results[e.id]['sum']] if x])
         exams['sum'] = sum_all
         exams['max'] = max_all
+        exams['max_rel'] = max_rel
     exams_with_registration = [e for e in lecture.exams.all() if e.registration != None]
     registrations = {}
     for reg in request.db.query(models.ExamAdmission).filter(models.ExamAdmission.exam_id.in_([e.id for e in exams_with_registration])).filter(models.ExamAdmission.student_id == ls.student_id).all():


### PR DESCRIPTION
Currently, the `view_points` page only displays the "total achieved points / total achievable points" percentage in the "Punkte" section. Personally, I found this to be inconvenient when comparing my points with the exam admission threshold because the points of exercise sheets that are not yet released or corrected are included in the number of total achievable points.

This PR adds a second percentage, namely "total achieved points / total achievable points of already graded exercise sheets" and displays it next to the other percentage in a way similar to the Übungsgruppenverwaltungssystem of the Faculty of Physics and Astronomy. This percentage is shown iff there are ungraded sheets.

![image](https://user-images.githubusercontent.com/74795488/146645668-b505d637-00c4-441d-85d6-7d10656bbfe2.png)
