### PR TITLE
Revert "Bump numpy from 1.19.3 to 1.21.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ marshmallow==3.14.1
 matplotlib==2.2.0
 natsort==7.0.1
 networkx==2.5
-numpy==1.21.0
+numpy==1.19.3
 openpyxl==2.5.0
 Paste==3.5.0
 PasteDeploy==2.1.1


### PR DESCRIPTION
Reverts muesli-hd/muesli#151

https://numpy.org/devdocs/release/1.21.0-notes.html
This is a build break, we have to either update python or use an older `numpy` release (

have: python3.6, https://packages.ubuntu.com/bionic/python3
want: python3.7-3.9